### PR TITLE
fix: use tf log for sdk logging

### DIFF
--- a/internal/provider/log.go
+++ b/internal/provider/log.go
@@ -1,0 +1,35 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type TerraformLog struct {
+}
+
+func (tl TerraformLog) Debug(msg string, args ...any) {
+	tflog.Debug(context.Background(), msg, tl.argsToMap(args))
+}
+func (tl TerraformLog) Info(msg string, args ...any) {
+	tflog.Info(context.Background(), msg, tl.argsToMap(args))
+}
+func (tl TerraformLog) Warn(msg string, args ...any) {
+	tflog.Warn(context.Background(), msg, tl.argsToMap(args))
+}
+func (tl TerraformLog) Error(msg string, args ...any) {
+	tflog.Error(context.Background(), msg, tl.argsToMap(args))
+}
+func (tl TerraformLog) argsToMap(args ...any) map[string]interface{} {
+	result := make(map[string]any)
+	for i := 0; i < len(args)-1; i += 2 {
+		if key, ok := args[i].(string); ok {
+			result[key] = args[i+1]
+		}
+	}
+	return result
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,7 +6,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 
 	"terraform-provider-tasks/internal/sdk"
@@ -134,7 +133,7 @@ func (p *RightbrainProvider) newRightbrainClient(data RightbrainProviderModel) (
 	if err != nil {
 		return nil, err
 	}
-	return sdk.NewTasksClient(slog.Default(), http.DefaultClient, tokenStore, sdk.Config{
+	return sdk.NewTasksClient(TerraformLog{}, http.DefaultClient, tokenStore, sdk.Config{
 		RightbrainAPIHost:      p.isEmptyValueElseDefault(data.RightbrainAPIHost, DefaultAPIHost),
 		RightbrainClientID:     data.RightbrainClientID.ValueString(),
 		RightbrainClientSecret: data.RightbrainClientSecret.ValueString(),


### PR DESCRIPTION
This PR provides a log wrapper around the logging instance provided by Terraform so that our SDK can write to it too.