### PR TITLE
feat: add support for input processors

### DIFF
--- a/docs/resources/task.md
+++ b/docs/resources/task.md
@@ -28,9 +28,29 @@ Task resource
 
 - `description` (String) A description of the Task.
 - `image_required` (Boolean)
+- `input_processors` (Block, Optional) (see [below for nested schema](#nestedblock--input_processors))
 - `public` (Boolean)
 
 ### Read-Only
 
 - `active_revision_id` (String)
 - `id` (String) Identifier
+
+<a id="nestedblock--input_processors"></a>
+### Nested Schema for `input_processors`
+
+Optional:
+
+- `input_processor` (Block List) (see [below for nested schema](#nestedblock--input_processors--input_processor))
+
+<a id="nestedblock--input_processors--input_processor"></a>
+### Nested Schema for `input_processors.input_processor`
+
+Required:
+
+- `input_processor` (String)
+- `param_name` (String)
+
+Optional:
+
+- `config` (Map of String)

--- a/internal/provider/task_resource.go
+++ b/internal/provider/task_resource.go
@@ -236,22 +236,7 @@ func (r *TaskResource) Create(ctx context.Context, req resource.CreateRequest, r
 		in.OutputFormat[k] = v.ValueString()
 	}
 
-	if data.HasInputProcessors() {
-		in.InputProcessors = &[]entitites.InputProcessor{}
-		for _, v := range data.InputProcessors.InputProcessors {
-			ip := entitites.InputProcessor{
-				ParamName:      v.ParamName.ValueString(),
-				InputProcessor: v.InputProcessor.ValueString(),
-			}
-			for k, v := range v.Config {
-				if ip.Config == nil {
-					ip.Config = make(map[string]string)
-				}
-				ip.Config[k] = v.ValueString()
-			}
-			*in.InputProcessors = append(*in.InputProcessors, ip)
-		}
-	}
+	*in.InputProcessors = *r.FormatInputProcessors(data)
 
 	task, err := r.client.Create(ctx, in)
 	if err != nil {
@@ -316,24 +301,7 @@ func (r *TaskResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		in.OutputFormat[k] = v.ValueString()
 	}
 
-	in.InputProcessors = &[]entitites.InputProcessor{}
-
-	if data.HasInputProcessors() {
-		for _, v := range data.InputProcessors.InputProcessors {
-			ip := entitites.InputProcessor{
-
-				ParamName:      v.ParamName.ValueString(),
-				InputProcessor: v.InputProcessor.ValueString(),
-			}
-			for k, v := range v.Config {
-				if ip.Config == nil {
-					ip.Config = make(map[string]string)
-				}
-				ip.Config[k] = v.ValueString()
-			}
-			*in.InputProcessors = append(*in.InputProcessors, ip)
-		}
-	}
+	*in.InputProcessors = *r.FormatInputProcessors(data)
 
 	task, err := r.client.Update(ctx, in)
 	if err != nil {
@@ -369,4 +337,26 @@ func (r *TaskResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 func (r *TaskResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *TaskResource) FormatInputProcessors(data TaskResourceModel) *[]entitites.InputProcessor {
+	ips := []entitites.InputProcessor{}
+	if !data.HasInputProcessors() {
+		return &ips
+	}
+	for _, v := range data.InputProcessors.InputProcessors {
+		ip := entitites.InputProcessor{
+
+			ParamName:      v.ParamName.ValueString(),
+			InputProcessor: v.InputProcessor.ValueString(),
+		}
+		for k, v := range v.Config {
+			if ip.Config == nil {
+				ip.Config = make(map[string]string)
+			}
+			ip.Config[k] = v.ValueString()
+		}
+		ips = append(ips, ip)
+	}
+	return &ips
 }

--- a/internal/sdk/entities/task.go
+++ b/internal/sdk/entities/task.go
@@ -35,16 +35,27 @@ func (t *Task) GetLatestRevision() (*Revision, error) {
 
 // Revision represents a single revision in the "revisions" array.
 type Revision struct {
-	SystemPrompt    string       `json:"system_prompt"`
-	UserPrompt      string       `json:"user_prompt"`
-	LLMModelID      string       `json:"llm_model_id"`
-	OutputFormat    OutputFormat `json:"output_format"`
-	ID              string       `json:"id"`
-	InputParams     []string     `json:"input_params"`
-	TaskForwarderID string       `json:"task_forwarder_id"`
-	ImageRequired   bool         `json:"image_required"`
-	Active          bool         `json:"active"`
-	RAG             RAG          `json:"rag"`
+	SystemPrompt    string            `json:"system_prompt"`
+	UserPrompt      string            `json:"user_prompt"`
+	LLMModelID      string            `json:"llm_model_id"`
+	OutputFormat    OutputFormat      `json:"output_format"`
+	ID              string            `json:"id"`
+	InputParams     []string          `json:"input_params"`
+	TaskForwarderID string            `json:"task_forwarder_id"`
+	ImageRequired   bool              `json:"image_required"`
+	Active          bool              `json:"active"`
+	RAG             RAG               `json:"rag"`
+	InputProcessors *[]InputProcessor `json:"input_processors"`
+}
+
+func (r *Revision) HasInputProcessors() bool {
+	return r.InputProcessors != nil && len(*r.InputProcessors) > 0
+}
+
+type InputProcessor struct {
+	ParamName      string            `json:"param_name"`
+	InputProcessor string            `json:"input_processor"`
+	Config         map[string]string `json:"config"`
 }
 
 // OutputFormat represents the structure of the output format in a revision.

--- a/internal/sdk/requests.go
+++ b/internal/sdk/requests.go
@@ -3,16 +3,21 @@
 
 package sdk
 
+import (
+	entitites "terraform-provider-tasks/internal/sdk/entities"
+)
+
 type CreateTaskRequest struct {
-	Description   string            `json:"description"`
-	Enabled       bool              `json:"enabled"`
-	ImageRequired bool              `json:"image_required"`
-	LLMModelID    string            `json:"llm_model_id"`
-	Name          string            `json:"name"`
-	OutputFormat  map[string]string `json:"output_format"`
-	Public        bool              `json:"public"`
-	SystemPrompt  string            `json:"system_prompt"`
-	UserPrompt    string            `json:"user_prompt"`
+	Description     string                      `json:"description"`
+	Enabled         bool                        `json:"enabled"`
+	ImageRequired   bool                        `json:"image_required"`
+	InputProcessors *[]entitites.InputProcessor `json:"input_processors"`
+	LLMModelID      string                      `json:"llm_model_id"`
+	Name            string                      `json:"name"`
+	OutputFormat    map[string]string           `json:"output_format"`
+	Public          bool                        `json:"public"`
+	SystemPrompt    string                      `json:"system_prompt"`
+	UserPrompt      string                      `json:"user_prompt"`
 }
 
 func NewCreateTaskRequest() CreateTaskRequest {
@@ -22,16 +27,17 @@ func NewCreateTaskRequest() CreateTaskRequest {
 }
 
 type UpdateTaskRequest struct {
-	ID            string            `json:"id"`
-	Description   string            `json:"description"`
-	Enabled       bool              `json:"enabled"`
-	ImageRequired bool              `json:"image_required"`
-	LLMModelID    string            `json:"llm_model_id"`
-	Name          string            `json:"name"`
-	OutputFormat  map[string]string `json:"output_format"`
-	Public        bool              `json:"public"`
-	SystemPrompt  string            `json:"system_prompt"`
-	UserPrompt    string            `json:"user_prompt"`
+	ID              string                      `json:"id"`
+	Description     string                      `json:"description"`
+	Enabled         bool                        `json:"enabled"`
+	ImageRequired   bool                        `json:"image_required"`
+	InputProcessors *[]entitites.InputProcessor `json:"input_processors"`
+	LLMModelID      string                      `json:"llm_model_id"`
+	Name            string                      `json:"name"`
+	OutputFormat    map[string]string           `json:"output_format"`
+	Public          bool                        `json:"public"`
+	SystemPrompt    string                      `json:"system_prompt"`
+	UserPrompt      string                      `json:"user_prompt"`
 }
 
 func NewUpdateTaskRequest(id string) UpdateTaskRequest {


### PR DESCRIPTION
This PR adds support for `input_processors` to the provider

```hcl
resource "rightbrain_task" "dummy_task" {
  name        = "Dummy Task Name"
  enabled     = true

  llm_model_id = data.rightbrain_model.claude_3_5_sonnet_20241022.id

  system_prompt = <<-EOF
    You tell the bestest jokes
  EOF

  user_prompt = <<-EOF
    Tell me a joke about {website}
  EOF

  output_format = {
    "output_str" : "str"
  }

  input_processors {
    input_processor {
      param_name = "website"
      input_processor = "url_fetcher"
      config = {
        fallback_text: "clowns"
      }
    }
  }
}
